### PR TITLE
Updates for GOV.UK Frontend 5.3.0

### DIFF
--- a/GOV.UK Design System Snippets.novaextension/CHANGELOG.md
+++ b/GOV.UK Design System Snippets.novaextension/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.06
+* added the Password Input component
+* removed `role` attributes
+
 ## Version 1.05
 
 * added the Exit This Page component

--- a/GOV.UK Design System Snippets.novaextension/Clips.json
+++ b/GOV.UK Design System Snippets.novaextension/Clips.json
@@ -39,7 +39,7 @@
           "trigger" : "gov-confirmation-page"
         },
         {
-          "content" : "<div class=\"govuk-grid-column-one-third\">\n\n  <aside class=\"app-related-items\" role=\"complementary\">\n\t<h2 class=\"govuk-heading-m\" id=\"subsection-title\">\n\t  Subsection\n\t<\/h2>\n\t<nav role=\"navigation\" aria-labelledby=\"subsection-title\">\n\t  <ul class=\"govuk-list govuk-!-font-size-16\">\n\t\t<li>\n\t\t  <a href=\"#\">\n\t\t\tRelated link\n\t\t  <\/a>\n\t\t<\/li>\n\t\t<li>\n\t\t  <a href=\"#\">\n\t\t\tRelated link\n\t\t  <\/a>\n\t\t<\/li>\n\t\t<li>\n\t\t  <a href=\"#\" class=\"govuk-!-font-weight-bold\">\n\t\t\tMore <span class=\"govuk-visually-hidden\">in Subsection<\/span>\n\t\t  <\/a>\n\t\t<\/li>\n\t  <\/ul>\n\t<\/nav>\n  <\/aside>\n\n<\/div>",
+          "content" : "<div class=\"govuk-grid-column-one-third\">\n\n  <aside class=\"app-related-items\">\n\t<h2 class=\"govuk-heading-m\" id=\"subsection-title\">\n\t  Subsection\n\t<\/h2>\n\t<nav aria-labelledby=\"subsection-title\">\n\t  <ul class=\"govuk-list govuk-!-font-size-16\">\n\t\t<li>\n\t\t  <a href=\"#\">\n\t\t\tRelated link\n\t\t  <\/a>\n\t\t<\/li>\n\t\t<li>\n\t\t  <a href=\"#\">\n\t\t\tRelated link\n\t\t  <\/a>\n\t\t<\/li>\n\t\t<li>\n\t\t  <a href=\"#\" class=\"govuk-!-font-weight-bold\">\n\t\t\tMore <span class=\"govuk-visually-hidden\">in Subsection<\/span>\n\t\t  <\/a>\n\t\t<\/li>\n\t  <\/ul>\n\t<\/nav>\n  <\/aside>\n\n<\/div>",
           "name" : "GOV.UK Layout Aside",
           "scope" : "editor",
           "trigger" : "gov-layout-aside"
@@ -298,6 +298,12 @@
           "name" : "GOV.UK Panel",
           "scope" : "editor",
           "trigger" : "gov-panel"
+        },
+        {
+          "content" : "{{ govukPasswordInput({\n\tid: '$0',\n\tname: '$0',\n\tvalue: data['$0'],\n\tclasses: 'govuk-input--width-${1:Character width: 20, 10, 5, 4, 3, 2} govuk-!-width-${2:Fraction width: full, three-quarters, two-thirds, one-hlaf, one-third, one-quarter}',\n\tlabel: {\n\t\thtml: '$3',\n\t\tclasses: '${4:govuk-label--l}',\n\t\tisPageHeading: ${5:true or false}\n\t},\n\thint: {\n\t\thtml: '$6'\n\t},\n\tautocomplete: '${7:Password type: current-password, new-password}'\n}) }}$99",
+          "name" : "GOV.UK Password Input",
+          "scope" : "editor",
+          "trigger" : "gov-password-input"
         },
         {
           "content" : "{{ govukPhaseBanner({\n\ttag: {\n\t\ttext: '${0:beta}'\n\t},\n\thtml: '${1:This is a new service – your <a class=\"govuk-link\" href=\"#\">feedback<\/a> will help us to improve it.}'\n}) }}",

--- a/GOV.UK Design System Snippets.novaextension/README.md
+++ b/GOV.UK Design System Snippets.novaextension/README.md
@@ -2,7 +2,7 @@
 
 This extension provides Nunjucks clips/snippets for the [GOV.UK Design System](https://design-system.service.gov.uk/), including styles, components, and patterns.
 
-It was last updated with GOV.‌UK Frontend v5.1.0.
+It was last updated with GOV.‌UK Frontend v5.3.0.
 
 ## Installation
 
@@ -67,6 +67,7 @@ Start typing `GOV.UK` to see a list of all snippets or fuzzy match any of the sp
 * Pagination: Labels
 * Pagination: Large
 * Panel
+* Password Input
 * Phase Banner
 * Radios
 * Radio

--- a/GOV.UK Design System Snippets.novaextension/extension.json
+++ b/GOV.UK Design System Snippets.novaextension/extension.json
@@ -3,7 +3,7 @@
     "name": "GOV.UK Design System Snippets",
     "organization": "Chris Armstrong",
     "description": "Snippets for the styles, components and patterns from the GOV.UK Design System.",
-    "version": "1.05",
+    "version": "1.06",
     "categories": ["clips"],
     "repository": "https://github.com/chrisadesign/GOV.UK-Design-System-Nova-snippets",
     "bugs": "https://github.com/chrisadesign/GOV.UK-Design-System-Nova-snippets/issues"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This extension provides Nunjucks clips/snippets for the [GOV.UK Design System](https://design-system.service.gov.uk/), including styles, components, and patterns.
 
-It was last updated with GOV.‌UK Frontend v5.1.0.
+It was last updated with GOV.‌UK Frontend v5.3.0.
 
 ## Installation
 
@@ -67,6 +67,7 @@ Start typing `GOV.UK` to see a list of all snippets or fuzzy match any of the sp
 * Pagination: Labels
 * Pagination: Large
 * Panel
+* Password Input
 * Phase Banner
 * Radios
 * Radio


### PR DESCRIPTION
- Added snippet for the new Password Input component.
- Removed `role` attributes from some snippets. We no longer recommend having these where the role can already be inferred from the element type. 